### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM google/cloud-sdk
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get update && apt-get install -y  \
+        nodejs \
+        make \
+        ruby \
+        ruby-dev  && \
+        gem install --no-rdoc --no-ri sass:3.4.22 \
+        compass && \
+        node -v


### PR DESCRIPTION
This Dockerfile is based on  `google/cloud-sdk:latest`

It has the following commands: 
```
- curl -sL https://deb.nodesource.com/setup_6.x | bash -
- apt-get install -y nodejs
- apt-get install make
- apt-get install -y ruby
- apt-get install -y ruby-dev
- gem install --no-rdoc --no-ri sass -v 3.4.22
- gem install --no-rdoc --no-ri compass
```